### PR TITLE
avoid "here" links

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,19 +86,19 @@
 	    <section id="main_content">
 	        <h3>JSR 354 Specification (API)</h3>
 			<p>
-			 Find more details on the API/specification <a href="api.html">here</a>.
+			 Find more details on the <a href="api.html">API/specification</a>.
 			</p>
 			<h3>JSR 354 Reference Implementation (RI)</h3>
 			<p>
-			 Check out the referenceimplementation <a href="ri.html">here</a>.
+			 Check out the <a href="ri.html">reference implementation</a>.
 			</p>
 			<h3>Technical Compatibility Kit (TCK)</h3>
 			<p>
-			 Want to write your own implementation of JSR 354? The you should also checkout and configure the TCK. Start <a href="tck.html">here</a>.
+			 Want to write your own implementation of JSR 354? Then you should also checkout and configure the <a href="tck.html">TCK</a>.
 			</p>
 			<h3>JavaMoney Financial Library</h3>
 			<p>
-			 Find out more about the JavaMoney Financial Library <a href="lib.html">here</a>.
+			 Find out more about the <a href="lib.html">JavaMoney Financial Library</a>.
 			</p>
 		</section>
 	<hr/>


### PR DESCRIPTION
"here" links are a bad UX practice (e.g. [Why Your Links Should Never Say “Click Here”](http://uxmovement.com/content/why-your-links-should-never-say-click-here/)) - and for me personally an annoyance worth submitting a pull request ;)